### PR TITLE
Issue 64

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -57,7 +57,7 @@ class ParticipantsController < ApplicationController
 
   def destroy
     @participant = current_participant
-    if @participant.update_attributes(deactivated: true)
+    if @participant.deactivatable? && @participant.update_attributes(deactivated: true)
       flash[:success] = 'アカウントを削除しました。'
     else
       flash[:danger] = 'アカウントの削除に失敗しました。'

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -70,4 +70,22 @@ class Participant < ApplicationRecord
   def self.find_by_email(email)
     Participant.find_by(email: email, deactivated: false)
   end
+
+  def deactivatable?
+    for s in schedules do
+      if s.datetime > DateTime.now
+        for a in s.applications do
+          if a.status != 2
+            return false
+          end
+        end
+      end
+    end
+    for e in events do
+      if e.start_at > DateTime.now
+        return false
+      end
+    end
+    return true
+  end
 end

--- a/app/views/participants/_destroy.html.erb
+++ b/app/views/participants/_destroy.html.erb
@@ -1,6 +1,6 @@
 <p>※実験終了後ログインしないまま7日が経過すると自動的にアカウントが削除されます。</p>
 
-<% if participant.schedules.blank? || participant.events.blank? %>
+<% if participant.schedules.blank? && participant.events.blank? %>
     <%= link_to '今、アカウントを削除する', deactivate_path, method: :delete, title: '確認',
                 data: { confirm: '本当にアカウントを削除してよろしいですか？',
                         commit:  '削除する',

--- a/app/views/participants/_destroy.html.erb
+++ b/app/views/participants/_destroy.html.erb
@@ -1,7 +1,11 @@
 <p>※実験終了後ログインしないまま7日が経過すると自動的にアカウントが削除されます。</p>
 
-<%= link_to '今、アカウントを削除する', deactivate_path, method: :delete, title: '確認',
-            data: { confirm: '本当にアカウントを削除してよろしいですか？',
-                    commit:  '削除する',
-                    cancel:  'キャンセル', },
-            class: 'form-control btn btn-danger' %>
+<% if participant.schedules.blank? || participant.events.blank? %>
+    <%= link_to '今、アカウントを削除する', deactivate_path, method: :delete, title: '確認',
+                data: { confirm: '本当にアカウントを削除してよろしいですか？',
+                        commit:  '削除する',
+                        cancel:  'キャンセル', },
+                        class: 'form-control btn btn-danger' %>
+<% else%>
+    <p> あなたはまだ終了していない応募済みの実験があるためアカウントを削除できません。</p>
+<% end %>

--- a/app/views/participants/_destroy.html.erb
+++ b/app/views/participants/_destroy.html.erb
@@ -1,11 +1,12 @@
 <p>※実験終了後ログインしないまま7日が経過すると自動的にアカウントが削除されます。</p>
 
-<% if participant.schedules.blank? && participant.events.blank? %>
+<% if participant.deactivatable? %>
     <%= link_to '今、アカウントを削除する', deactivate_path, method: :delete, title: '確認',
                 data: { confirm: '本当にアカウントを削除してよろしいですか？',
                         commit:  '削除する',
                         cancel:  'キャンセル', },
                         class: 'form-control btn btn-danger' %>
 <% else%>
-    <p> あなたはまだ終了していない応募済みの実験があるためアカウントを削除できません。</p>
+    <%= link_to '今、アカウントを削除する',"", disabled: true, class: 'form-control btn btn-danger' %>
+    <p> 予定が残っているためアカウントを削除できません。 </p>
 <% end %>

--- a/test/fixtures/applications.yml
+++ b/test/fixtures/applications.yml
@@ -2,3 +2,8 @@ one:
   participant_id: 1
   schedule_id: 1
   status: 0
+
+two:
+  participant_id: 2
+  schedule_id: 5
+  status: 0

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -8,3 +8,14 @@ one:
   duration: 10
   experiment_id: 1
   participant_id: 1
+
+two:
+  id: 2
+  name: 事前手続き
+  requirement: 印鑑(シャチハタ以外)
+  description: 事前手続きです。
+  place: 総合研究7号館207号室
+  start_at: 2100-03-10 12:00:00
+  duration: 10
+  experiment_id: 2
+  participant_id: 2

--- a/test/fixtures/schedules.yml
+++ b/test/fixtures/schedules.yml
@@ -19,3 +19,8 @@ four:
   id: 4
   experiment_id: 1
   datetime: 2017-02-17 14:00:00
+
+five:
+  id: 5
+  experiment_id: 2
+  datetime: 2100-02-17 14:00:00

--- a/test/integration/participants_deactivate_test.rb
+++ b/test/integration/participants_deactivate_test.rb
@@ -17,7 +17,11 @@ class ParticipantsDeactivateTest < ActionDispatch::IntegrationTest
   test "get settings and deactivate" do
     log_in_as_participant @participant
     get settings_path
-    assert_select "a[href=?]", deactivate_path
+    if @participant.schedules.blank? && @participant.events.blank?
+      assert_select "a[href=?]", deactivate_path
+    else
+      assert_select "a[href=?]", deactivate_path, false
+    end
     deactivate
     assert_redirected_to login_url
     follow_redirect!

--- a/test/integration/participants_deactivate_test.rb
+++ b/test/integration/participants_deactivate_test.rb
@@ -17,19 +17,19 @@ class ParticipantsDeactivateTest < ActionDispatch::IntegrationTest
   test "get settings and deactivate" do
     log_in_as_participant @participant
     get settings_path
-    if @participant.schedules.blank? && @participant.events.blank?
+    if @participant.deactivatable?
       assert_select "a[href=?]", deactivate_path
+      deactivate
+      assert_redirected_to login_url
+      follow_redirect!
+      assert_not flash.empty?
+      assert_not is_logged_in_participant?
+      @participant.reload
+      assert @participant.deactivated
+      get login_path
+      assert flash.empty?
     else
       assert_select "a[href=?]", deactivate_path, false
     end
-    deactivate
-    assert_redirected_to login_url
-    follow_redirect!
-    assert_not flash.empty?
-    assert_not is_logged_in_participant?
-    @participant.reload
-    assert @participant.deactivated
-    get login_path
-    assert flash.empty?
   end
 end

--- a/test/integration/participants_deactivate_test.rb
+++ b/test/integration/participants_deactivate_test.rb
@@ -17,19 +17,29 @@ class ParticipantsDeactivateTest < ActionDispatch::IntegrationTest
   test "get settings and deactivate" do
     log_in_as_participant @participant
     get settings_path
-    if @participant.deactivatable?
-      assert_select "a[href=?]", deactivate_path
-      deactivate
-      assert_redirected_to login_url
-      follow_redirect!
-      assert_not flash.empty?
-      assert_not is_logged_in_participant?
-      @participant.reload
-      assert @participant.deactivated
-      get login_path
-      assert flash.empty?
-    else
-      assert_select "a[href=?]", deactivate_path, false
-    end
+    assert_select "a[href=?]", deactivate_path
+    deactivate
+    assert_redirected_to login_url
+    follow_redirect!
+    assert_not flash.empty?
+    assert_not is_logged_in_participant?
+    @participant.reload
+    assert @participant.deactivated
+    get login_path
+    assert flash.empty?
+
+    @participant = participants(:two) # 終了していないイベントやスケジュールのあるアカウント
+    log_in_as_participant @participant
+    get settings_path
+    assert_select "a[href=?]", deactivate_path, false
+    deactivate
+    assert_redirected_to login_url
+    follow_redirect!
+    assert_not flash.empty?
+    assert_not is_logged_in_participant?
+    @participant.reload
+    assert_not @participant.deactivated
+    get login_path
+    assert flash.empty?
   end
 end


### PR DESCRIPTION
`participant` の `schedules` 及び `events` が空の場合のみボタンを表示するようにした
そうでない場合は退会できない旨を代わりに表示
